### PR TITLE
Multiple fixes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -84,6 +84,8 @@ Then set up a system cron job to run your application's Cron once a minute:
 The included `run.php` should work for most cases, but you are free to call `Cron::run()`
 in any way you see fit.
 
+## Log activities
+
 In order to use the logs within the module, you'll have to put $_log var to true
 	
 	protected static $_log = true

--- a/README.markdown
+++ b/README.markdown
@@ -38,6 +38,9 @@ For example,
 	Cron::set('reindex_catalog', array('@daily', 'Catalog::regenerate_index'));
 	Cron::set('calendar_notifications', array('*/5 * * * *', 'Calendar::send_emails'));
 
+Always remember that if you change a frequency value, remove the entry into the cache file
+for that method. If you don't do this, the next call to the method will be with the last cached frequence.
+
 Configured tasks are run with their appropriate frequency by calling `Cron::run()`. Call
 this method in your bootstrap file, and you're done!
 
@@ -80,6 +83,14 @@ Then set up a system cron job to run your application's Cron once a minute:
 
 The included `run.php` should work for most cases, but you are free to call `Cron::run()`
 in any way you see fit.
+
+In order to use the logs within the module, you'll have to put $_log var to true
+	
+	protected static $_log = true
+
+And give an output to your cron job. It should look like this:
+
+	* * * * * /usr/bin/php -f /path/to/kohana/modules/cron/run.php >> log.txt #
 
 
 ## Multi-streaming and using groups

--- a/README.markdown
+++ b/README.markdown
@@ -84,7 +84,7 @@ Then set up a system cron job to run your application's Cron once a minute:
 The included `run.php` should work for most cases, but you are free to call `Cron::run()`
 in any way you see fit.
 
-## Log activities
+## Enabling logs
 
 In order to use the logs within the module, you'll have to put $_log var to true
 	


### PR DESCRIPTION
- Added comments to methods.
- Updated _load method in order to always get the cached data instead of getting empty data because of the default lifetime value at 60s and run.php that runs at each 60s. (bug fix) 
- Updated _save method by removing useless parameters
- Rewrite execute method. Use Request::factory instead of call_user_func function
- Updated code for Kohana 3.2.2
- Updated README
